### PR TITLE
Add the Wistron 6512-32R platform sku sensor data and skip unsupported test items

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -7279,3 +7279,76 @@ sensors_checks:
       temp: [ ]
     psu_skips: { }
     sensor_skip_per_version: { }
+
+  x86_64-wistron_6512_32r-r0:
+    alarms:
+      fan: []
+      power: []
+      temp: []
+
+    compares:
+      fan: []
+      power: []
+
+      temp:
+      - - wistron_thermal-i2c-0-48/temp1/temp1_input
+        - wistron_thermal-i2c-0-48/temp1/temp1_max
+      - - wistron_thermal-i2c-0-49/temp1/temp1_input
+        - wistron_thermal-i2c-0-49/temp1/temp1_max
+      - - wistron_thermal-i2c-0-4a/temp1/temp1_input
+        - wistron_thermal-i2c-0-4a/temp1/temp1_max
+      - - wistron_thermal-i2c-0-4b/temp1/temp1_input
+        - wistron_thermal-i2c-0-4b/temp1/temp1_max
+      - - wistron_thermal-i2c-0-4c/temp1/temp1_input
+        - wistron_thermal-i2c-0-4c/temp1/temp1_max
+      - - wistron_thermal-i2c-0-4d/temp1/temp1_input
+        - wistron_thermal-i2c-0-4d/temp1/temp1_max
+      - - wistron_thermal-i2c-0-4f/temp1/temp1_input
+        - wistron_thermal-i2c-0-4f/temp1/temp1_max
+      - - wistron_thermal-i2c-0-68/temp1/temp1_input
+        - wistron_thermal-i2c-0-68/temp1/temp1_max
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_crit
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_crit
+      - - coretemp-isa-0000/Core 2/temp4_input
+        - coretemp-isa-0000/Core 2/temp4_crit
+      - - coretemp-isa-0000/Core 3/temp5_input
+        - coretemp-isa-0000/Core 3/temp5_crit
+    non_zero:
+      fan:
+      - wistron_fan-i2c-0-44/fan1/fan1_input
+      - wistron_fan-i2c-0-44/fan2/fan2_input
+      - wistron_fan-i2c-0-44/fan3/fan3_input
+      - wistron_fan-i2c-0-44/fan4/fan4_input
+      - wistron_fan-i2c-0-44/fan5/fan5_input
+      - wistron_fan-i2c-0-44/fan6/fan6_input
+      - wistron_fan-i2c-0-44/fan7/fan7_input
+      - wistron_fan-i2c-0-44/fan8/fan8_input
+      - wistron_fan-i2c-0-44/fan9/fan9_input
+      - wistron_fan-i2c-0-44/fan10/fan10_input
+      - wistron_fan-i2c-0-44/fan11/fan11_input
+      - wistron_fan-i2c-0-44/fan12/fan12_input
+      - wistron_fan-i2c-0-44/fan13/fan13_input
+      - wistron_fan-i2c-0-44/fan14/fan14_input
+      power:
+      - wistron_psu2-i2c-0-59/in1/in1_input
+      - wistron_psu2-i2c-0-59/in2/in2_input
+      - wistron_psu2-i2c-0-59/power1/power1_input
+      - wistron_psu2-i2c-0-59/power2/power2_input
+      - wistron_psu2-i2c-0-59/curr1/curr1_input
+      - wistron_psu2-i2c-0-59/curr2/curr2_input
+      - wistron_psu1-i2c-0-5a/in1/in1_input
+      - wistron_psu1-i2c-0-5a/in2/in2_input
+      - wistron_psu1-i2c-0-5a/power1/power1_input
+      - wistron_psu1-i2c-0-5a/power2/power2_input
+      - wistron_psu1-i2c-0-5a/curr1/curr1_input
+      - wistron_psu1-i2c-0-5a/curr2/curr2_input
+
+      temp:
+      - wistron_psu2-i2c-0-59/temp1/temp1_input
+      - wistron_psu1-i2c-0-5a/temp1/temp1_input
+
+    psu_skips: {}
+
+    sensor_skip_per_version: {}

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -34,6 +34,12 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_presence:
     conditions:
       - "asic_type in ['mellanox']"
 
+platform_tests/api/test_chassis.py::TestChassisApi::test_get_reboot_cause:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
+
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_revision:
   xfail:
     reason: "[DX010] Testcase consistently fails, raised issue to track; [E1031] API 'get_revision' not implemented"
@@ -59,21 +65,20 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_thermal_manager:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "'sw_to3200k' in hwsku"
+      - "('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog:
   skip:
     reason: "Unsupported platform API"
     conditions_logical_operator: 'OR'
     conditions:
-      - "asic_type in ['barefoot'] and hwsku in ['newport']"
-      - "'sw_to3200k' in hwsku"
+      - "asic_type in ['barefoot'] and hwsku in ['newport'] or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox'] or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
   xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
@@ -200,7 +205,7 @@ platform_tests/api/test_component.py::TestComponentApi::test_install_firmware:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox'] or ('sw_to3200k' in hwsku)"
+      - "asic_type in ['mellanox'] or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
 
 platform_tests/api/test_component.py::TestComponentApi::test_is_replaceable:
   skip:
@@ -661,7 +666,7 @@ platform_tests/api/test_watchdog.py:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['barefoot'] and hwsku in ['newport', 'montara'] or ('sw_to3200k' in hwsku)"
+      - "asic_type in ['barefoot'] and hwsku in ['newport', 'montara'] or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
       - "platform in ['x86_64-nokia_ixr7250e_sup-r0', 'x86_64-nokia_ixr7250e_36x400g-r0']"
 
 #######################################
@@ -718,6 +723,12 @@ platform_tests/cli/test_show_platform.py::test_show_platform_psustatus_json:
   skip:
     reason: "Test should be skipped on DPU for it doesn't have PSUs."
     conditions: "'nvda_bf' in platform"
+
+platform_tests/cli/test_show_platform.py::test_show_platform_ssdhealth:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
 
 platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom:
   xfail:
@@ -892,7 +903,7 @@ platform_tests/test_platform_info.py::test_thermal_control_load_invalid_format_j
     reason: "Skip on Cisco platform and multi-asic platform running 201911 release / Test not required on Mellanox Platforms as all thermal policies have been removed from thermalctld"
     conditions_logical_operator: or
     conditions:
-      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911']) or ('dell_s6100' in platform) or ('sw_to3200k' in hwsku)"
+      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911']) or ('dell_s6100' in platform) or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
       - "asic_type in ['mellanox']"
 
 platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_json:
@@ -905,7 +916,7 @@ platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_js
     reason: "Skip on Cisco platform and multi-asic platform running 201911 release / Test not required on Mellanox Platforms as all thermal policies have been removed from thermalctld"
     conditions_logical_operator: or
     conditions:
-      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911']) or ('dell_s6100' in platform) or ('sw_to3200k' in hwsku)"
+      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911']) or ('dell_s6100' in platform) or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
       - "asic_type in ['mellanox']"
 
 platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus:
@@ -923,7 +934,7 @@ platform_tests/test_power_off_reboot.py:
   skip:
     reason: "Skip power off reboot test for Wistron/Nokia-7215"
     conditions:
-      - "(hwsku in ['Celestica-E1031-T48S4']) or ('sw_to3200k' in hwsku) or (platform in ['armhf-nokia_ixs7215_52x-r0']) or (is_multi_asic==True and release in ['201911'])"
+      - "(hwsku in ['Celestica-E1031-T48S4']) or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku) or (platform in ['armhf-nokia_ixs7215_52x-r0']) or (is_multi_asic==True and release in ['201911'])"
 
 platform_tests/test_reboot.py::test_cold_reboot:
   xfail:
@@ -974,7 +985,7 @@ platform_tests/test_reboot.py::test_watchdog_reboot:
     reason: "Skip watchdog reboot test for Wistron / Nokia 7215 / cisco platform x86_64-8102_64h_o-r0"
     conditions_logical_operator: or
     conditions:
-      - "'sw_to3200k' in hwsku or platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - "('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku) or platform in ['armhf-nokia_ixs7215_52x-r0']"
 
 #######################################
 #####   test_reload_config.py     #####
@@ -1043,3 +1054,7 @@ platform_tests/test_xcvr_info_in_db.py::test_xcvr_info_in_db:
     conditions:
       - "platform in ['x86_64-cel_e1031-r0']"
       - https://github.com/sonic-net/sonic-buildimage/issues/18231
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add the Wistron 6512-32R platform sku sensor data and skip unsupported test items

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Add the Wistron 6512-32R platform sku sensor data for testing and skipped unsupported test items

#### How did you do it?
Add the definition for 6512-32R in Added the skip in the common sku-sensors data and skip file.

#### How did you verify/test it?
Run the testbed with Wistron 6512-32R

#### Any platform specific information?
Specific to hwsku Wistron 6512-32R

#### Supported testbed topology if it's a new test case?

### Documentation

